### PR TITLE
Have inline() method uses its argument to decide whether to inline as markdown or html

### DIFF
--- a/index.js
+++ b/index.js
@@ -394,7 +394,7 @@ Glog.prototype.list = function (opts, cb) {
     }
 };
 
-Glog.prototype.inline = function () {
+Glog.prototype.inline = function (format) {
     var self = this;
     var em = new OrderedEmitter;
     em.on('data', function (doc) {
@@ -412,7 +412,8 @@ Glog.prototype.inline = function () {
         var n = order ++;
         pending ++;
 
-        s.pipe(concat(function (body) {
+        var stream = (format === 'html' ? self.markdownToHtml(s) : s);
+        stream.pipe(concat(function (body) {
             doc.body = body.toString('utf8');
             em.emit('data', { order : n, value : doc });
         }));


### PR DESCRIPTION
I inadvertently broke HTML inlining in 0f2706fba387e4db21cc5320edf7b78ef621d152 when I changed `Glog#read` to not do markdown->html parsing.

The API docs in `REAMDME.md` refer to the `Glog#inline` method accepting 'markdown' or 'html', but the method actually accepts neither and always returns the body as-is. This commit changes that, and, as a result, also gets articles rendering in proper HTML when `inline('html')` is invoked. Sorry about that.